### PR TITLE
Faster, more accurate Poisson Binomial PMF

### DIFF
--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -77,21 +77,6 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
     end
 end
 
-# Test the _dft helper function
-@testset "_dft" begin
-    x = Distributions._dft(collect(1:8))
-    # Comparator computed from FFTW
-    fftw_fft = [36.0 + 0.0im,
-                -4.0 + 9.65685424949238im,
-                -4.0 + 4.0im,
-                -4.0 + 1.6568542494923806im,
-                -4.0 + 0.0im,
-                -4.0 - 1.6568542494923806im,
-                -4.0 - 4.0im,
-                -4.0 - 9.65685424949238im]
-    @test x ≈ fftw_fft
-end
-
 # Test autodiff using ForwardDiff
 f = x -> logpdf(PoissonBinomial(x), 0)
 at = [0.5, 0.5]


### PR DESCRIPTION
I have done a lot of research in evaluating poisson binomial pmf in last 3 years. The simplest and fastest continues to be the recursive formula. I've cited Thomas & Taub (1982) but it predates this article as well because it is related to evaluating the elementary symmetric function. The Hong (2013) article does a very bad job at evaluating and comparing their method. 

```julia
julia> x = [3.5118, .6219, .2905, .8450, 1.8648]
julia> p = big.(x) ./ (1 .+ big.(x))
julia> @benchmark poisbin_sum_taub(p)
BenchmarkTools.Trial: 
  memory estimate:  10.20 KiB
  allocs estimate:  230
  --------------
  minimum time:     7.075 μs (0.00% GC)
  median time:      7.525 μs (0.00% GC)
  mean time:        9.559 μs (12.27% GC)
  maximum time:     2.087 ms (66.47% GC)
  --------------
  samples:          10000
  evals/sample:     4

julia> @benchmark Distributions.poissonbinomial_pdf_fft(p)
BenchmarkTools.Trial: 
  memory estimate:  188.90 KiB
  allocs estimate:  4155
  --------------
  minimum time:     515.800 μs (0.00% GC)
  median time:      523.201 μs (0.00% GC)
  mean time:        558.614 μs (3.83% GC)
  maximum time:     9.248 ms (62.80% GC)
  --------------
  samples:          8935
  evals/sample:     1

julia> sum(abs.(poisbin_sum_taub(p) .- naive_sol))
1.106509096121475717627626332421301195049237546693398552456162007115350824780186e-77
julia> sum(abs.(Distributions.poissonbinomial_pdf_fft(p) .- naive_sol))
3.197437330491599664330118659436447055371737441489833207203143282015769955768403e-17
```

One method which does truly scale better than the recursive algorithm is Biscarri (2018), but it is a lot more involved but I do have it implemented in julia in a separate package right now. In simulation study you can see that it has comparable error rate, but is faster than the recursive algorithm for long inputs (see figure below where DFT-CF is Hong (2013), Taub is recursive algorithm implemented in this PR, and DC-FFT is Biscarri (2018)). 

![pmf_sim](https://user-images.githubusercontent.com/805168/96204605-59871480-0f2a-11eb-8759-f0bbb4e34ebd.png)
